### PR TITLE
ajustes de seguridad para login en producción

### DIFF
--- a/backend/ricco/settings.py
+++ b/backend/ricco/settings.py
@@ -8,7 +8,7 @@ from decouple import config  # ✅ Lee las variables del archivo .env
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # === DEBUG: True para desarrollo, False para producción ===
-DEBUG = config('DEBUG', default=True, cast=bool)
+DEBUG = config('DEBUG', default=False, cast=bool)
 
 # === SECRET_KEY: clave secreta del proyecto Django ===
 SECRET_KEY = config('SECRET_KEY', default='insecure-dev-key')
@@ -202,6 +202,8 @@ cloudinary.config(
   api_secret = config('CLOUDINARY_API_SECRET') 
 )
 
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 # from pathlib import Path
 # from datetime import timedelta


### PR DESCRIPTION
se agregó SESSION_COOKIE_SECURE y CSRF_COOKIE_SECURE en settings.py y se forzó DEBUG=False en entorno de Render. Esto permite que el backend maneje correctamente las cookies y tokens en producción, resolviendo el problema de login desde el frontend desplegado.

Motivo: en local funcionaba correctamente, pero en Render el backend no devolvía el token por fallos en la configuración de seguridad y entorno.